### PR TITLE
feat: add Maven Central publishing support

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,0 +1,42 @@
+name: Publish to Maven Central
+
+on:
+  # Manual trigger for testing
+  workflow_dispatch:
+  # Automatically publish when a release is created
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "23"
+          distribution: "temurin"
+
+      - name: Install Coursier
+        run: |
+          curl -fLo cs https://git.io/coursier-cli-linux
+          chmod +x cs
+          sudo mv cs /usr/local/bin/cs
+
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.MAVEN_GPG_SECRET_BASE64 }}" | base64 -d | gpg --batch --import
+          # List keys to verify import
+          gpg --list-secret-keys
+
+      - name: Publish to Maven Central
+        run: ./mill mill.javalib.SonatypeCentralPublishModule/
+        env:
+          MILL_PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MILL_PGP_SECRET_BASE64: ${{ secrets.MAVEN_GPG_SECRET_BASE64 }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.MAVEN_REPO_SECRET }}
+          MILL_SONATYPE_USERNAME: ${{ vars.MAVEN_REPO_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ node_modules/
 .private
 
 planning_docs/old
+private

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ help:
 	@echo "  make check     - Full check (compile + test + lint)"
 	@echo "  make release   - Prepare release (check + assembly)"
 	@echo ""
+	@echo "Publishing:"
+	@echo "  make publish-local    - Publish to local Ivy repo"
+	@echo "  make publish-m2       - Publish to local Maven repo"
+	@echo "  make publish-central  - Publish to Maven Central"
+	@echo "  make publish-dry-run  - Test publishing config"
+	@echo ""
 	@echo "Use 'make <target> -n' to see what commands will run"
 
 # ============================================================================
@@ -182,6 +188,36 @@ ci: clean check
 .PHONY: release
 release: check assembly docs
 	@echo "📦 Release artifacts ready!"
+
+# ============================================================================
+# PUBLISHING
+# ============================================================================
+.PHONY: publish-local
+publish-local:
+	@./mill __.publishLocal
+	@echo "✅ Published to local Ivy repository (~/.ivy2/local)"
+
+.PHONY: publish-m2
+publish-m2:
+	@./mill __.publishM2Local
+	@echo "✅ Published to local Maven repository (~/.m2/repository)"
+
+.PHONY: publish-central
+publish-central:
+	@echo "Publishing to Maven Central..."
+	@echo "Make sure you have set:"
+	@echo "  - MILL_SONATYPE_USERNAME"
+	@echo "  - MILL_SONATYPE_PASSWORD" 
+	@echo "  - MILL_PGP_SECRET_BASE64"
+	@echo "  - MILL_PGP_PASSPHRASE"
+	@./mill mill.javalib.SonatypeCentralPublishModule/
+	@echo "✅ Published to Maven Central!"
+
+.PHONY: publish-dry-run
+publish-dry-run:
+	@echo "Dry run - checking publishing configuration..."
+	@./mill __.publishLocal --transitive=false
+	@echo "✅ Dry run complete - check ~/.ivy2/local for artifacts"
 
 # ============================================================================
 # PROJECT INFO

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-import mill._, scalalib._
+import mill._, scalalib._, publish._
 import scala.util.{Try, Success, Failure}
 
 case class GitHubDependency(
@@ -98,7 +98,17 @@ trait GitHubDepsModule extends ScalaModule {
   }
 }
 
-trait Shared extends GitHubDepsModule {
+trait PublishSettings extends SonatypeCentralPublishModule {
+
+  def publishVersion = Task.Input {
+    val packageJsonPath = os.pwd / os.up / os.up / os.up / "package.json"
+    val packageJson = os.read(packageJsonPath)
+    val json = upickle.default.read[ujson.Value](packageJson)
+    json.obj("version").str
+  }
+}
+
+trait Shared extends GitHubDepsModule with PublishSettings {
   def scalaVersion = "3.7.2"
 
   // Suppress the "caps" warning which is a known Scala 3 issue
@@ -187,12 +197,26 @@ trait Shared extends GitHubDepsModule {
 }
 
 object Chez extends Shared {
+  override def artifactName = "chez"
+
   override def mvnDeps = Task {
     super.mvnDeps() ++ Seq()
   }
+
+  override def pomSettings = PomSettings(
+    description = "Chez - Type-safe JSON Schema library for Scala 3",
+    organization = "com.silvabyte",
+    url = "https://github.com/silvabyte/Chez",
+    licenses = Seq(License.MIT),
+    versionControl = VersionControl.github("silvabyte", "Chez"),
+    developers = Seq(
+      Developer("matsilva", "Mat Silva", "https://github.com/matsilva")
+    )
+  )
 }
 
 object CaskChez extends Shared {
+  override def artifactName = "caskchez"
   override def moduleDeps: Seq[Shared] = Seq(Chez)
   override def mvnDeps = Task {
     super.mvnDeps() ++ Seq(
@@ -200,9 +224,21 @@ object CaskChez extends Shared {
       mvn"com.lihaoyi::scalatags:0.13.1"
     )
   }
+
+  override def pomSettings = PomSettings(
+    description = "CaskChez - HTTP API framework with automatic validation using Chez schemas",
+    organization = "com.silvabyte",
+    url = "https://github.com/silvabyte/Chez",
+    licenses = Seq(License.MIT),
+    versionControl = VersionControl.github("silvabyte", "Chez"),
+    developers = Seq(
+      Developer("matsilva", "Mat Silva", "https://github.com/matsilva")
+    )
+  )
 }
 
 object ChezWiz extends Shared {
+  override def artifactName = "chezwiz"
   override def moduleDeps: Seq[Shared] = Seq(Chez)
   override def mvnDeps = Task {
     super.mvnDeps() ++ Seq(
@@ -211,4 +247,14 @@ object ChezWiz extends Shared {
     )
   }
 
+  override def pomSettings = PomSettings(
+    description = "ChezWiz - AI/LLM agent framework using Chez schemas",
+    organization = "com.silvabyte",
+    url = "https://github.com/silvabyte/Chez",
+    licenses = Seq(License.MIT),
+    versionControl = VersionControl.github("silvabyte", "Chez"),
+    developers = Seq(
+      Developer("matsilva", "Mat Silva", "https://github.com/matsilva")
+    )
+  )
 }


### PR DESCRIPTION
## Summary
- Configure Maven Central publishing for all Chez modules
- Add automated publishing via GitHub Actions

## Changes
- **build.mill**: Configure `SonatypeCentralPublishModule` for Chez, CaskChez, and ChezWiz modules
- **GitHub Actions**: Add workflow for automated publishing on release or manual trigger
- **Version management**: Read version from package.json for consistency
- **Makefile**: Add convenient targets for publishing tasks

## Configuration
The publishing setup uses:
- Namespace: `com.silvabyte`
- Version source: `package.json`
- Publishing to Sonatype Central Portal (not legacy OSSRH)

## GitHub Secrets Required
Before merging, configure these in repository settings:
- `MAVEN_GPG_SECRET_BASE64` (secret)
- `MAVEN_GPG_PASSPHRASE` (secret) 
- `MAVEN_REPO_SECRET` (secret)
- `MAVEN_REPO_USERNAME` (variable)

## Testing
```bash
# Test local publishing
make publish-local

# Test Maven Central publishing (requires secrets)
make publish-central
```