### PR TITLE
docs: add detailed documentation for Chez and ChezWiz

### DIFF
--- a/docs/chez.md
+++ b/docs/chez.md
@@ -43,6 +43,8 @@ schema.validate(json) // Right(()) or Left(List(...))
 - Metadata: `title`, `description`, `examples`, `deprecated`, `readOnly`, `writeOnly`
 - Defaults: `default(value)` (type‑safe)
 
+→ [Annotations: Full Docs](./chez/annotations.md)
+
 ## Unions, Option, Nulls
 
 - `A | B` → JSON Schema `oneOf`

--- a/docs/chez/annotations.md
+++ b/docs/chez/annotations.md
@@ -1,0 +1,425 @@
+# Annotations Guide
+
+Chez provides rich annotation support for JSON Schema validation. Annotations define constraints and metadata directly in your types, enabling precise validation at boundaries.
+
+## Basic Usage
+
+Apply annotations to case class fields using `@Schema.*`:
+
+```scala
+import chez.derivation.Schema
+
+@Schema.title("User Profile")
+@Schema.description("System user")
+case class User(
+  @Schema.description("Unique ID")
+  @Schema.format("uuid")
+  id: String,
+
+  @Schema.description("Display name")
+  @Schema.minLength(2)
+  @Schema.maxLength(100)
+  name: String,
+
+  @Schema.description("User age")
+  @Schema.minimum(0)
+  @Schema.maximum(120)
+  age: Int
+) derives Schema
+```
+
+## String Annotations
+
+### Length Constraints
+
+```scala
+case class Message(
+  @Schema.minLength(1)      // At least 1 character
+  @Schema.maxLength(280)    // At most 280 characters
+  content: String
+) derives Schema
+```
+
+### Format Validation
+
+```scala
+case class Contact(
+  @Schema.format("email")       // RFC 5322 email format
+  email: String,
+
+  @Schema.format("uuid")        // UUID format
+  id: String,
+
+  @Schema.format("date")        // ISO 8601 date
+  birthDate: String,
+
+  @Schema.format("uri")         // Valid URI
+  website: String
+) derives Schema
+```
+
+### Pattern Matching
+
+```scala
+case class Product(
+  @Schema.pattern("^prod-[0-9]+$")     // Product ID format
+  id: String,
+
+  @Schema.pattern("^[a-z0-9-]+$")      // Slug format
+  slug: String,
+
+  @Schema.pattern("^\\+?[1-9]\\d{1,14}$")  // International phone
+  phone: String
+) derives Schema
+```
+
+### Constant Values
+
+```scala
+case class ApiResponse(
+  @Schema.const("success")      // Must be exactly "success"
+  status: String,
+
+  @Schema.const("1.0")         // API version constant
+  version: String
+) derives Schema
+```
+
+## Number Annotations
+
+### Range Constraints
+
+```scala
+case class Product(
+  @Schema.minimum(0.01)         // At least $0.01
+  @Schema.maximum(999999.99)    // At most $999,999.99
+  price: Double,
+
+  @Schema.exclusiveMinimum(0.0) // Greater than 0 (not equal)
+  @Schema.exclusiveMaximum(100.0) // Less than 100 (not equal)
+  percentage: Double,
+
+  @Schema.multipleOf(0.01)      // Must be multiple of 0.01
+  precisePrice: Double
+) derives Schema
+```
+
+### Integer Constraints
+
+```scala
+case class User(
+  @Schema.minimum(0)            // Non‑negative
+  @Schema.maximum(150)          // Reasonable age limit
+  age: Int,
+
+  @Schema.multipleOf(5)         // Must be multiple of 5
+  rating: Int
+) derives Schema
+```
+
+## Array Annotations
+
+### Size Constraints
+
+```scala
+case class User(
+  @Schema.minItems(1)           // At least 1 tag
+  @Schema.maxItems(10)          // At most 10 tags
+  @Schema.uniqueItems(true)     // No duplicates
+  tags: List[String],
+
+  @Schema.minItems(0)           // Can be empty
+  @Schema.maxItems(5)           // Max 5 items
+  categories: List[String]
+) derives Schema
+```
+
+## Enumeration Annotations
+
+### String Enums
+
+```scala
+case class Order(
+  @Schema.enumValues("pending", "processing", "shipped", "delivered")
+  status: String
+) derives Schema
+```
+
+### Mixed Type Enums
+
+```scala
+case class Setting(
+  @Schema.enumValues("auto", 1, true, 3.14, null)
+  value: String | Int | Boolean | Double | Null
+) derives Schema
+```
+
+## Metadata Annotations
+
+### Documentation
+
+```scala
+@Schema.title("Product Catalog Item")
+@Schema.description("Represents a product in our e-commerce catalog")
+@Schema.examples("""{"id": "prod-123", "name": "Widget", "price": 9.99}""")
+case class Product(
+  @Schema.description("Unique product identifier")
+  @Schema.examples("prod-123", "prod-456")
+  id: String,
+
+  @Schema.description("Product display name")
+  name: String,
+
+  @Schema.description("Price in USD")
+  price: Double
+) derives Schema
+```
+
+### Field Visibility
+
+```scala
+case class User(
+  @Schema.readOnly(true)        // Only in responses, not requests
+  id: String,
+
+  @Schema.writeOnly(true)       // Only in requests, not responses
+  password: String,
+
+  @Schema.deprecated(true)      // Mark as deprecated
+  @Schema.description("Use 'fullName' instead")
+  name: String,
+
+  fullName: String
+) derives Schema
+```
+
+## Default Values
+
+```scala
+case class Settings(
+  @Schema.default("en")         // Default language
+  language: String,
+
+  @Schema.default(true)         // Default enabled
+  notifications: Boolean,
+
+  @Schema.default(10)           // Default page size
+  pageSize: Int,
+
+  @Schema.default(1.0)          // Default version
+  version: Double
+) derives Schema
+```
+
+## Complex Examples
+
+### User Registration
+
+```scala
+@Schema.title("User Registration")
+@Schema.description("New user registration data")
+case class UserRegistration(
+  @Schema.description("Username (3-20 alphanumeric + underscore)")
+  @Schema.minLength(3)
+  @Schema.maxLength(20)
+  @Schema.pattern("^[a-zA-Z0-9_]+$")
+  username: String,
+
+  @Schema.description("Valid email address")
+  @Schema.format("email")
+  email: String,
+
+  @Schema.description("Strong password (8+ chars, uppercase, digit)")
+  @Schema.minLength(8)
+  @Schema.pattern("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)")
+  password: String,
+
+  @Schema.description("User age (must be 13+)")
+  @Schema.minimum(13)
+  @Schema.maximum(120)
+  age: Int,
+
+  @Schema.description("Agreed to terms of service")
+  @Schema.const(true)           // Must be true
+  agreeToTerms: Boolean
+) derives Schema
+```
+
+### E‑commerce Product
+
+```scala
+@Schema.title("Product")
+@Schema.description("E-commerce product with full validation")
+case class Product(
+  @Schema.description("Product SKU")
+  @Schema.pattern("^[A-Z]{3}-\\d{6}$")
+  @Schema.examples("ELE-123456", "CLO-789012")
+  sku: String,
+
+  @Schema.description("Product name")
+  @Schema.minLength(1)
+  @Schema.maxLength(200)
+  name: String,
+
+  @Schema.description("Product description")
+  @Schema.maxLength(2000)
+  description: Option[String],
+
+  @Schema.description("Price in USD (minimum $0.01)")
+  @Schema.minimum(0.01)
+  @Schema.maximum(999999.99)
+  @Schema.multipleOf(0.01)
+  price: Double,
+
+  @Schema.description("Product category")
+  @Schema.enumValues("electronics", "clothing", "books", "food", "other")
+  category: String,
+
+  @Schema.description("Product tags")
+  @Schema.minItems(0)
+  @Schema.maxItems(10)
+  @Schema.uniqueItems(true)
+  tags: List[String],
+
+  @Schema.description("Currently in stock")
+  @Schema.default(true)
+  inStock: Boolean,
+
+  @Schema.description("Product rating (1-5 stars)")
+  @Schema.minimum(1.0)
+  @Schema.maximum(5.0)
+  @Schema.multipleOf(0.5)       // Half-star ratings
+  rating: Option[Double]
+) derives Schema
+```
+
+### API Configuration
+
+```scala
+@Schema.title("API Configuration")
+@Schema.description("Service configuration with validation")
+case class ApiConfig(
+  @Schema.description("Service name")
+  @Schema.minLength(1)
+  @Schema.maxLength(50)
+  @Schema.pattern("^[a-zA-Z][a-zA-Z0-9-]*$")
+  serviceName: String,
+
+  @Schema.description("Service version")
+  @Schema.pattern("^\\d+\\.\\d+\\.\\d+$")
+  @Schema.examples("1.0.0", "2.1.3")
+  version: String,
+
+  @Schema.description("Environment")
+  @Schema.enumValues("development", "staging", "production")
+  @Schema.default("development")
+  environment: String,
+
+  @Schema.description("Server port")
+  @Schema.minimum(1024)
+  @Schema.maximum(65535)
+  @Schema.default(8080)
+  port: Int,
+
+  @Schema.description("Enable debug logging")
+  @Schema.default(false)
+  debug: Boolean,
+
+  @Schema.description("Database connection string")
+  @Schema.format("uri")
+  @Schema.pattern("^(postgresql|mysql)://.*")
+  databaseUrl: String,
+
+  @Schema.description("Allowed origins for CORS")
+  @Schema.minItems(0)
+  @Schema.maxItems(20)
+  allowedOrigins: List[String]
+) derives Schema
+```
+
+## Annotation Combinations
+
+Multiple annotations work together:
+
+```scala
+case class StrictField(
+  @Schema.description("Highly constrained field")
+  @Schema.minLength(5)          // At least 5 chars
+  @Schema.maxLength(50)         // At most 50 chars
+  @Schema.pattern("^[A-Z][a-zA-Z0-9]*$")  // Start with uppercase
+  @Schema.format("custom")      // Custom format
+  value: String
+) derives Schema
+```
+
+## Validation Results
+
+Annotations generate detailed validation errors:
+
+```scala
+val schema = Schema[User]
+val json = ujson.Obj("name" -> "", "age" -> -5)
+
+schema.validate(json) match {
+  case Right(()) => println("Valid")
+  case Left(errors) =>
+    errors.foreach(println)
+    // MinLengthViolation: name must be at least 2 characters
+    // OutOfRange: age must be >= 0
+}
+```
+
+## Best Practices
+
+### 1. Document Everything
+
+```scala
+@Schema.title("Clear Title")
+@Schema.description("Detailed description of purpose and usage")
+case class WellDocumented(
+  @Schema.description("Explain what this field represents")
+  field: String
+) derives Schema
+```
+
+### 2. Use Realistic Constraints
+
+```scala
+case class RealisticUser(
+  @Schema.minLength(2)          // Reasonable minimum
+  @Schema.maxLength(100)        // Reasonable maximum
+  name: String,
+
+  @Schema.minimum(13)           // Legal minimum
+  @Schema.maximum(150)          // Biological maximum
+  age: Int
+) derives Schema
+```
+
+### 3. Provide Examples
+
+```scala
+@Schema.examples("""{"username": "john_doe", "email": "john@example.com"}""")
+case class ExampleRich(
+  @Schema.examples("john_doe", "jane_smith")
+  username: String,
+
+  @Schema.examples("john@example.com", "jane@company.org")
+  email: String
+) derives Schema
+```
+
+### 4. Use Enums for Fixed Sets
+
+```scala
+case class BetterThanStrings(
+  @Schema.enumValues("small", "medium", "large", "xl")
+  size: String,  // Better than unconstrained String
+
+  @Schema.enumValues(1, 2, 3, 4, 5)
+  priority: Int  // Better than unconstrained Int
+) derives Schema
+```
+
+Annotations provide precise, self‑documenting validation that ensures data quality at your API boundaries.
+

--- a/docs/chezwiz.md
+++ b/docs/chezwiz.md
@@ -65,10 +65,14 @@ val agent = Agent("Local", "You are helpful.", local, model = "local-model")
 - Provide `RequestMetadata(tenantId, userId, conversationId)` to scope history.
 - Use `generateTextWithoutHistory` for stateless calls.
 
+→ [Detailed Guide: Metadata & Scoping](./chezwiz/metadata-and-scoping.md)
+
 ## Hooks & Metrics
 
 - Register hooks for logging/metrics/tracing; combine multiple hooks.
 - Built‑in metrics helpers available; export to Prometheus or JSON if desired.
+
+→ [Detailed Guide: Hooks & Metrics](./chezwiz/hooks-and-metrics.md)
 
 ## Run Examples
 

--- a/docs/chezwiz/hooks-and-metrics.md
+++ b/docs/chezwiz/hooks-and-metrics.md
@@ -1,0 +1,228 @@
+# Hooks & Metrics
+
+ChezWiz provides a comprehensive hook system for observability and metrics collection, enabling you to monitor agent performance, log interactions, and implement custom business logic.
+
+## Hook System
+
+Hooks are lifecycle events that fire during agent operations. Each hook type receives specific context data:
+
+### Available Hook Types
+
+- **PreRequestHook**: Before sending requests to LLM providers
+- **PostResponseHook**: After receiving responses from LLM providers
+- **PreObjectRequestHook**: Before structured object generation requests
+- **PostObjectResponseHook**: After structured object generation responses
+- **ErrorHook**: When errors occur during operations
+- **HistoryHook**: When conversation history changes
+- **ScopeChangeHook**: When conversation scope changes
+- **PreEmbeddingHook**: Before embedding requests
+- **PostEmbeddingHook**: After embedding responses
+
+### Creating Custom Hooks
+
+Implement hook traits for custom functionality:
+
+```scala
+import chezwiz.agent.*
+
+class LoggingHook extends PreRequestHook with PostResponseHook {
+  def onPreRequest(context: PreRequestContext): Unit = {
+    println(s"[${context.agentName}] Starting request: ${context.request.messages.last.content}")
+  }
+
+  def onPostResponse(context: PostResponseContext): Unit = {
+    context.response match {
+      case Right(response) =>
+        println(s"[${context.agentName}] Success in ${context.duration}ms")
+      case Left(error) =>
+        println(s"[${context.agentName}] Error: ${error}")
+    }
+  }
+}
+```
+
+### Registering Hooks
+
+Use `HookRegistry` to combine multiple hooks:
+
+```scala
+val logging = new LoggingHook()
+val metrics = new MetricsHook(new DefaultAgentMetrics())
+
+val hooks = HookRegistry.empty
+  .addPreRequestHook(logging)
+  .addPostResponseHook(logging)
+  .addPreRequestHook(metrics)
+  .addPostResponseHook(metrics)
+
+val agent = Agent("MyAgent", "You are helpful", provider, "gpt-4o", hooks = hooks)
+```
+
+## Built‑in Metrics
+
+ChezWiz includes a comprehensive metrics system that tracks performance, usage, and errors automatically.
+
+### Quick Setup with MetricsFactory
+
+The easiest way to get metrics is using `MetricsFactory`:
+
+```scala
+import chezwiz.agent.MetricsFactory
+
+val result = MetricsFactory.createOpenAIAgentWithMetrics(
+  name = "ProductionAgent",
+  instructions = "You are a helpful assistant",
+  apiKey = sys.env("OPENAI_API_KEY"),
+  model = "gpt-4o"
+)
+
+result match {
+  case Right((agent, metrics)) =>
+    // Use agent normally, metrics collected automatically
+    agent.generateText("Hello world", metadata)
+
+    // View metrics
+    val snapshot = metrics.getSnapshot("ProductionAgent")
+    println(snapshot.map(_.summary))
+  case Left(error) => println(s"Setup failed: $error")
+}
+```
+
+### Manual Metrics Setup
+
+For more control, use `MetricsHook` directly:
+
+```scala
+val metrics = new DefaultAgentMetrics()
+val metricsHook = new MetricsHook(metrics)
+
+val hooks = HookRegistry.empty
+  .addPreRequestHook(metricsHook)
+  .addPostResponseHook(metricsHook)
+  .addPreObjectRequestHook(metricsHook)
+  .addPostObjectResponseHook(metricsHook)
+  .addErrorHook(metricsHook)
+  .addHistoryHook(metricsHook)
+
+val agent = Agent("MyAgent", "Instructions", provider, "gpt-4o", hooks = hooks)
+```
+
+### Metrics Data
+
+Collected metrics include:
+
+- **Request counts**: Total, successful, failed
+- **Performance**: Average/min/max duration, success rates
+- **Usage**: Token consumption by model and operation
+- **Scope analytics**: Per‑tenant/user/conversation metrics
+- **Error tracking**: Error types, frequencies, samples
+- **Recent activity**: Request rates and trends
+
+### Exporting Metrics
+
+Export metrics in multiple formats:
+
+```scala
+val snapshot = metrics.getSnapshot("MyAgent")
+
+// Human‑readable summary
+println(snapshot.map(_.summary))
+
+// Prometheus format
+println(snapshot.map(_.toPrometheusFormat))
+
+// JSON export
+println(snapshot.map(_.toJson))
+
+// Global metrics export
+println(MetricsFactory.exportPrometheus)
+println(MetricsFactory.exportJson)
+```
+
+## Hook Context Data
+
+Each hook receives rich context information:
+
+### PreRequestContext
+
+```scala
+case class PreRequestContext(
+  agentName: String,
+  model: String,
+  request: ChatRequest,
+  metadata: RequestMetadata,
+  timestamp: Long
+)
+```
+
+### PostResponseContext
+
+```scala
+case class PostResponseContext(
+  agentName: String,
+  model: String,
+  request: ChatRequest,
+  response: Either[ChezError, ChatResponse],
+  metadata: RequestMetadata,
+  requestTimestamp: Long,
+  responseTimestamp: Long
+) {
+  def duration: Long = responseTimestamp - requestTimestamp
+}
+```
+
+### ErrorContext
+
+```scala
+case class ErrorContext(
+  agentName: String,
+  model: String,
+  error: ChezError,
+  metadata: RequestMetadata,
+  operation: String,
+  request: Option[Either[ChatRequest, ObjectRequest]],
+  timestamp: Long
+)
+```
+
+## Advanced Patterns
+
+### Combining Multiple Metrics Systems
+
+```scala
+val customMetrics = new MyCustomMetrics()
+val defaultMetrics = new DefaultAgentMetrics()
+
+val customHook = new MetricsHook(customMetrics)
+val defaultHook = new MetricsHook(defaultMetrics)
+
+val hooks = HookRegistry.empty
+  .addPreRequestHook(customHook)
+  .addPostResponseHook(customHook)
+  .addPreRequestHook(defaultHook)
+  .addPostResponseHook(defaultHook)
+```
+
+### Conditional Hook Execution
+
+```scala
+class ConditionalLoggingHook extends PreRequestHook {
+  def onPreRequest(context: PreRequestContext): Unit = {
+    if (context.metadata.tenantId.contains("debug")) {
+      println(s"Debug request: ${context.request}")
+    }
+  }
+}
+```
+
+### Global Metrics Access
+
+```scala
+// Replace global metrics instance
+MetricsFactory.setGlobalMetrics(new MyCustomMetrics())
+
+// Access global metrics
+val allMetrics = MetricsFactory.getAllMetrics
+val agentMetrics = MetricsFactory.getMetrics("MyAgent")
+```
+

--- a/docs/chezwiz/metadata-and-scoping.md
+++ b/docs/chezwiz/metadata-and-scoping.md
@@ -1,0 +1,71 @@
+# Metadata & Scoping
+
+ChezWiz uses `RequestMetadata` to scope conversations and enable stateful interactions across requests.
+
+## RequestMetadata
+
+```scala
+case class RequestMetadata(
+  tenantId: Option[String] = None,
+  userId: Option[String] = None,
+  conversationId: Option[String] = None
+)
+```
+
+- **tenantId**: Multi‑tenant isolation
+- **userId**: Per‑user conversation history
+- **conversationId**: Specific conversation thread
+
+## Scoped History
+
+Agents automatically maintain conversation history based on metadata:
+
+```scala
+val metadata = RequestMetadata(
+  userId = Some("alice"),
+  conversationId = Some("support-session-123")
+)
+
+// First message - starts new conversation
+agent.generateText("Hello, I need help with my account.", metadata)
+
+// Follow-up - continues same conversation
+agent.generateText("What's my current balance?", metadata)
+```
+
+## Stateless Requests
+
+Use `generateTextWithoutHistory` for one‑off requests:
+
+```scala
+// No history maintained
+val response = agent.generateTextWithoutHistory("Translate: Hello world")
+```
+
+## Conversation Isolation
+
+Different metadata creates separate conversation contexts:
+
+```scala
+val alice = RequestMetadata(userId = Some("alice"))
+val bob = RequestMetadata(userId = Some("bob"))
+
+// These maintain separate histories
+agent.generateText("My favorite color is blue", alice)
+agent.generateText("My favorite color is red", bob)
+```
+
+## Multi‑Tenant Usage
+
+Combine `tenantId` and `userId` for SaaS applications:
+
+```scala
+val metadata = RequestMetadata(
+  tenantId = Some("company-a"),
+  userId = Some("alice"),
+  conversationId = Some("onboarding")
+)
+```
+
+This ensures conversation history is isolated both by tenant and user.
+


### PR DESCRIPTION
## Summary

Added comprehensive documentation for Chez annotations and ChezWiz features:

• **docs/chez/annotations.md** - Complete guide to Chez schema annotations with examples
• **docs/chezwiz/metadata-and-scoping.md** - Guide to request metadata and conversation scoping  
• **docs/chezwiz/hooks-and-metrics.md** - Guide to hook system and metrics collection

## Changes

- Created detailed docs in new `docs/chez/` and `docs/chezwiz/` folders
- Updated main docs to link to detailed guides
- Consistent writing style and practical examples throughout